### PR TITLE
[TASK] Replace new.typo3.org with typo3.org

### DIFF
--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -20,7 +20,7 @@
                     <ul class="navbar-nav main-nav__list main-nav__meta-nav">
 
                         <li class="main-nav__meta-nav_item">
-                            <a href="https://new.typo3.org/cms/download/">
+                            <a href="https://typo3.org/cms/download/">
 
                                 <img class="main-nav__meta-nav_item-icon img-fluid"
                                      src="/assets/Gett3o/Assets/TYPO3_installation.svg"
@@ -42,7 +42,7 @@
                         </li>
 
                         <li class="main-nav__meta-nav_item">
-                            <a href="https://new.typo3.org/help/documentation/">
+                            <a href="https://typo3.org/help/documentation/">
 
                                 <img class="main-nav__meta-nav_item-icon img-fluid"
                                      src="/assets/Gett3o/Assets/TYPO3_doku.svg"
@@ -63,10 +63,10 @@
                 <div class="main-nav">
                     <nav class="navbar navbar-expand-lg navbar-light">
                         <div class="navbar-brand">
-                            <div class="logo"><a href="https://new.typo3.org/" target="_top" class="logoLink"
+                            <div class="logo"><a href="https://typo3.org/" target="_top" class="logoLink"
                                                  id="headerLogo"
                                                  title="Go to the start page"><img
-                                            src="https://new.typo3.org/typo3conf/ext/t3olayout/Resources/Public/Images/Template/typo3_nomargins.svg"
+                                            src="https://typo3.org/typo3conf/ext/t3olayout/Resources/Public/Images/Template/typo3_nomargins.svg"
                                             alt="TYPO3 Logo" title="Go to the start page"></a></div>
                         </div>
                         <button class="navbar-toggler ml-auto main-nav__burger js__main-nav__burger">
@@ -81,14 +81,14 @@
 
 
                                         <!-- Show all other links -->
-                                        <a href="https://new.typo3.org/project/" title="Open menu for The Project"
+                                        <a href="https://typo3.org/project/" title="Open menu for The Project"
                                            class="main-nav__list-item_link js__main-nav__list-item_link" data-id="3"
                                            data-level="1" data-sub="1">
                                             <span class="">The Project</span>
                                         </a>
 
 
-                                        <a href="https://new.typo3.org/project/"
+                                        <a href="https://typo3.org/project/"
                                            title="TYPO3 CMS is an open source CMS. The project is international and fully community-driven, and the long-term development is managed by the TYPO3 Association."
                                            class="main-nav__list-item_cross js__main-nav__list-item_cross"> </a>
 
@@ -96,7 +96,7 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/project/news/"
+                                                <a href="https://typo3.org/project/news/"
                                                    title="Read the latest news about TYPO3 CMS and the association and community supporting the word's most popular enterprise-level content management system."
                                                    class="sub-nav__list-item_link">News</a>
 
@@ -105,7 +105,7 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/project/products/"
+                                                <a href="https://typo3.org/project/products/"
                                                    title="TYPO3 CMS is our most important product. Fluid is a templating engine and Surf a deployment tool. They help deliver groundbreaking technology in TYPO3 CMS."
                                                    class="sub-nav__list-item_link">Our Products</a>
 
@@ -114,12 +114,12 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/project/association/"
+                                                <a href="https://typo3.org/project/association/"
                                                    title="The TYPO3 Association is a not-for-profit membership organization that coordinates and funds the long-term development of the TYPO3 CMS platform."
                                                    class="sub-nav__list-item_link">TYPO3 Association</a>
 
 
-                                                <a href="https://new.typo3.org/project/association/"
+                                                <a href="https://typo3.org/project/association/"
                                                    title="The TYPO3 Association is a not-for-profit membership organization that coordinates and funds the long-term development of the TYPO3 CMS platform."
                                                    class="main-nav__list-item_cross js__main-nav__list-item_cross">
                                                 </a>
@@ -127,47 +127,47 @@
                                                 <ul class="nav flex-column main-nav__list-item_sub-nav sub-nav__list js__sub-nav__list _lvl-3">
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/project/association/membership/"
+                                                        <a href="https://typo3.org/project/association/membership/"
                                                            class="sub-nav__list-item_link">Become a Member</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/project/association/members/"
+                                                        <a href="https://typo3.org/project/association/members/"
                                                            class="sub-nav__list-item_link">Our Members</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/project/association/structure/"
+                                                        <a href="https://typo3.org/project/association/structure/"
                                                            class="sub-nav__list-item_link">Structure</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/project/association/funding-finances/"
+                                                        <a href="https://typo3.org/project/association/funding-finances/"
                                                            class="sub-nav__list-item_link">Funding &amp; Finances</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/project/association/structure/general-assembly/"
+                                                        <a href="https://typo3.org/project/association/structure/general-assembly/"
                                                            class="sub-nav__list-item_link">General Assembly</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/project/association/association-projects/"
+                                                        <a href="https://typo3.org/project/association/association-projects/"
                                                            class="sub-nav__list-item_link">Association Projects</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/project/association/partnerships/"
+                                                        <a href="https://typo3.org/project/association/partnerships/"
                                                            class="sub-nav__list-item_link">Partnerships</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/project/association/by-laws/"
+                                                        <a href="https://typo3.org/project/association/by-laws/"
                                                            class="sub-nav__list-item_link">By-Laws</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/project/association/contact/"
+                                                        <a href="https://typo3.org/project/association/contact/"
                                                            class="sub-nav__list-item_link">Contact</a>
                                                     </li>
 
@@ -178,12 +178,12 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/project/brand/"
+                                                <a href="https://typo3.org/project/brand/"
                                                    title="Find information about how to use the brand and trademark rules, and learn how (not) to spell “TYPO3”."
                                                    class="sub-nav__list-item_link">The Brand</a>
 
 
-                                                <a href="https://new.typo3.org/project/brand/"
+                                                <a href="https://typo3.org/project/brand/"
                                                    title="Find information about how to use the brand and trademark rules, and learn how (not) to spell “TYPO3”."
                                                    class="main-nav__list-item_cross js__main-nav__list-item_cross">
                                                 </a>
@@ -191,22 +191,22 @@
                                                 <ul class="nav flex-column main-nav__list-item_sub-nav sub-nav__list js__sub-nav__list _lvl-3">
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/project/brand/trademarks/"
+                                                        <a href="https://typo3.org/project/brand/trademarks/"
                                                            class="sub-nav__list-item_link">Trademarks</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/project/brand/style-guide/"
+                                                        <a href="https://typo3.org/project/brand/style-guide/"
                                                            class="sub-nav__list-item_link">Style Guide</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/project/brand/typo3-slidedeck/"
+                                                        <a href="https://typo3.org/project/brand/typo3-slidedeck/"
                                                            class="sub-nav__list-item_link">TYPO3 slidedeck</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/project/brand/spelling-typo3/"
+                                                        <a href="https://typo3.org/project/brand/spelling-typo3/"
                                                            class="sub-nav__list-item_link">Spelling TYPO3</a>
                                                     </li>
 
@@ -217,7 +217,7 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/project/history/"
+                                                <a href="https://typo3.org/project/history/"
                                                    title="TYPO3 was developed from scratch by Kasper Skårhøj in 1997. Separating design and content was a smart solution to an emerging problem."
                                                    class="sub-nav__list-item_link">History</a>
 
@@ -226,12 +226,12 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/project/press/"
+                                                <a href="https://typo3.org/project/press/"
                                                    title="The TYPO3 Association is a not-for-profit organization, founded in 2004 to ensure the long-term development of the web-based content management system TYPO3 CMS."
                                                    class="sub-nav__list-item_link">Press</a>
 
 
-                                                <a href="https://new.typo3.org/project/press/"
+                                                <a href="https://typo3.org/project/press/"
                                                    title="The TYPO3 Association is a not-for-profit organization, founded in 2004 to ensure the long-term development of the web-based content management system TYPO3 CMS."
                                                    class="main-nav__list-item_cross js__main-nav__list-item_cross">
                                                 </a>
@@ -239,12 +239,12 @@
                                                 <ul class="nav flex-column main-nav__list-item_sub-nav sub-nav__list js__sub-nav__list _lvl-3">
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/project/press/press-releases/"
+                                                        <a href="https://typo3.org/project/press/press-releases/"
                                                            class="sub-nav__list-item_link">Press Releases</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/project/press/press-photos/"
+                                                        <a href="https://typo3.org/project/press/press-photos/"
                                                            class="sub-nav__list-item_link">Press Photos</a>
                                                     </li>
 
@@ -255,7 +255,7 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/project/licenses/"
+                                                <a href="https://typo3.org/project/licenses/"
                                                    title="TYPO3 products and extensions use GNU General Public License, where you are allowed to sell the extension as long as you do not change the license terms."
                                                    class="sub-nav__list-item_link">Licenses</a>
 
@@ -264,7 +264,7 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/project/technology-supporters/"
+                                                <a href="https://typo3.org/project/technology-supporters/"
                                                    title="This section is dedicated to our supporters offering their tools and services for free in the scope of open source software."
                                                    class="sub-nav__list-item_link">Technology Supporters</a>
 
@@ -280,14 +280,14 @@
 
 
                                         <!-- Show all other links -->
-                                        <a href="https://new.typo3.org/cms/" title="Open menu for TYPO3 CMS"
+                                        <a href="https://typo3.org/cms/" title="Open menu for TYPO3 CMS"
                                            class="main-nav__list-item_link js__main-nav__list-item_link" data-id="2"
                                            data-level="1" data-sub="1">
                                             <span class="">TYPO3 CMS</span>
                                         </a>
 
 
-                                        <a href="https://new.typo3.org/cms/"
+                                        <a href="https://typo3.org/cms/"
                                            title="Free and open source, TYPO3 CMS is a leading content management system with a&nbsp;feature set&nbsp;eclipsing that of our commercial and proprietary competitors."
                                            class="main-nav__list-item_cross js__main-nav__list-item_cross"> </a>
 
@@ -295,7 +295,7 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/cms/features/"
+                                                <a href="https://typo3.org/cms/features/"
                                                    title="TYPO3 CMS has thousands of features. This page gives a comprehensive, but far from complete, overview."
                                                    class="sub-nav__list-item_link">Features</a>
 
@@ -312,12 +312,12 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/cms/roadmap/"
+                                                <a href="https://typo3.org/cms/roadmap/"
                                                    title="The TYPO3 CMS development roadmap follows an 18-month release cycle for Long Term Support versions."
                                                    class="sub-nav__list-item_link">Roadmap</a>
 
 
-                                                <a href="https://new.typo3.org/cms/roadmap/"
+                                                <a href="https://typo3.org/cms/roadmap/"
                                                    title="The TYPO3 CMS development roadmap follows an 18-month release cycle for Long Term Support versions."
                                                    class="main-nav__list-item_cross js__main-nav__list-item_cross">
                                                 </a>
@@ -325,17 +325,17 @@
                                                 <ul class="nav flex-column main-nav__list-item_sub-nav sub-nav__list js__sub-nav__list _lvl-3">
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/cms/roadmap/release-news/"
+                                                        <a href="https://typo3.org/cms/roadmap/release-news/"
                                                            class="sub-nav__list-item_link">Release News</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/cms/roadmap/typo3-8-release-notes/"
+                                                        <a href="https://typo3.org/cms/roadmap/typo3-8-release-notes/"
                                                            class="sub-nav__list-item_link">TYPO3 8 Release Notes</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/cms/roadmap/typo3-7-release-notes/"
+                                                        <a href="https://typo3.org/cms/roadmap/typo3-7-release-notes/"
                                                            class="sub-nav__list-item_link">TYPO3 7 Release Notes</a>
                                                     </li>
 
@@ -346,7 +346,7 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/help/documentation/"
+                                                <a href="https://typo3.org/help/documentation/"
                                                    class="sub-nav__list-item_link">Documentation</a>
 
 
@@ -354,7 +354,7 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/cms/requirements/"
+                                                <a href="https://typo3.org/cms/requirements/"
                                                    title="It doesn't take a degree in engineering to get TYPO3 up an running. Find the facts and figures you need to get started with your first project."
                                                    class="sub-nav__list-item_link">System Requirements</a>
 
@@ -380,14 +380,14 @@
 
 
                                         <!-- Show all other links -->
-                                        <a href="https://new.typo3.org/community/" title="Open menu for Community"
+                                        <a href="https://typo3.org/community/" title="Open menu for Community"
                                            class="main-nav__list-item_link js__main-nav__list-item_link" data-id="4"
                                            data-level="1" data-sub="1">
                                             <span class="">Community</span>
                                         </a>
 
 
-                                        <a href="https://new.typo3.org/community/"
+                                        <a href="https://typo3.org/community/"
                                            title="The TYPO3 Community is growing, and we do&nbsp;more than just developing software.&nbsp;Everyone is welcome. Offer your skills and contribute to TYPO3."
                                            class="main-nav__list-item_cross js__main-nav__list-item_cross"> </a>
 
@@ -395,7 +395,7 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/community/events/"
+                                                <a href="https://typo3.org/community/events/"
                                                    title="There are quite some TYPO3 events during the year. You can take part in official events organized by the TYPO3 Association and events organized by the TYPO3 community."
                                                    class="sub-nav__list-item_link">Events</a>
 
@@ -404,12 +404,12 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/community/meet/"
+                                                <a href="https://typo3.org/community/meet/"
                                                    title="Online, at events, or in user groups. There are many ways to meet us."
                                                    class="sub-nav__list-item_link">Meet the Community</a>
 
 
-                                                <a href="https://new.typo3.org/community/meet/"
+                                                <a href="https://typo3.org/community/meet/"
                                                    title="Online, at events, or in user groups. There are many ways to meet us."
                                                    class="main-nav__list-item_cross js__main-nav__list-item_cross">
                                                 </a>
@@ -417,7 +417,7 @@
                                                 <ul class="nav flex-column main-nav__list-item_sub-nav sub-nav__list js__sub-nav__list _lvl-3">
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/community/meet/user-groups/"
+                                                        <a href="https://typo3.org/community/meet/user-groups/"
                                                            class="sub-nav__list-item_link">User Groups</a>
                                                     </li>
 
@@ -428,25 +428,25 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/community/contribute/"
+                                                <a href="https://typo3.org/community/contribute/"
                                                    class="sub-nav__list-item_link">Contribute
                                                     / Get Involved</a>
 
 
-                                                <a href="https://new.typo3.org/community/contribute/"
+                                                <a href="https://typo3.org/community/contribute/"
                                                    class="main-nav__list-item_cross js__main-nav__list-item_cross">
                                                 </a>
 
                                                 <ul class="nav flex-column main-nav__list-item_sub-nav sub-nav__list js__sub-nav__list _lvl-3">
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/project/association/membership/"
+                                                        <a href="https://typo3.org/project/association/membership/"
                                                            class="sub-nav__list-item_link">Become an Association
                                                             Member</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/community/contribute/donate/"
+                                                        <a href="https://typo3.org/community/contribute/donate/"
                                                            class="sub-nav__list-item_link">Donate</a>
                                                     </li>
 
@@ -457,12 +457,12 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/community/teams/"
+                                                <a href="https://typo3.org/community/teams/"
                                                    title="The teams and committees of the TYPO3 community take on tasks within specific areas, such as core development, education, communication and security."
                                                    class="sub-nav__list-item_link">Teams &amp; Committees</a>
 
 
-                                                <a href="https://new.typo3.org/community/teams/"
+                                                <a href="https://typo3.org/community/teams/"
                                                    title="The teams and committees of the TYPO3 community take on tasks within specific areas, such as core development, education, communication and security."
                                                    class="main-nav__list-item_cross js__main-nav__list-item_cross">
                                                 </a>
@@ -470,17 +470,17 @@
                                                 <ul class="nav flex-column main-nav__list-item_sub-nav sub-nav__list js__sub-nav__list _lvl-3">
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/community/teams/typo3-development/"
+                                                        <a href="https://typo3.org/community/teams/typo3-development/"
                                                            class="sub-nav__list-item_link">TYPO3 Development</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/community/teams/communication/"
+                                                        <a href="https://typo3.org/community/teams/communication/"
                                                            class="sub-nav__list-item_link">Communication</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/community/teams/typo3org/"
+                                                        <a href="https://typo3.org/community/teams/typo3org/"
                                                            class="sub-nav__list-item_link">typo3.org</a>
                                                     </li>
 
@@ -491,12 +491,12 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/community/values/"
+                                                <a href="https://typo3.org/community/values/"
                                                    title="TYPO3 is more than just a piece of software. It is a community. Our values guide our work and make sure the community is a great place for everyone."
                                                    class="sub-nav__list-item_link">Our Values</a>
 
 
-                                                <a href="https://new.typo3.org/community/values/"
+                                                <a href="https://typo3.org/community/values/"
                                                    title="TYPO3 is more than just a piece of software. It is a community. Our values guide our work and make sure the community is a great place for everyone."
                                                    class="main-nav__list-item_cross js__main-nav__list-item_cross">
                                                 </a>
@@ -504,23 +504,23 @@
                                                 <ul class="nav flex-column main-nav__list-item_sub-nav sub-nav__list js__sub-nav__list _lvl-3">
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/community/values/code-of-conduct/"
+                                                        <a href="https://typo3.org/community/values/code-of-conduct/"
                                                            class="sub-nav__list-item_link">Code of Conduct</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/community/values/leadership-code-of-conduct/"
+                                                        <a href="https://typo3.org/community/values/leadership-code-of-conduct/"
                                                            class="sub-nav__list-item_link">Leadership Code of
                                                             Conduct</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/community/values/event-code-of-conduct/"
+                                                        <a href="https://typo3.org/community/values/event-code-of-conduct/"
                                                            class="sub-nav__list-item_link">Event Code of Conduct</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/community/values/social-media-guidelines/"
+                                                        <a href="https://typo3.org/community/values/social-media-guidelines/"
                                                            class="sub-nav__list-item_link">Social Media Guidelines</a>
                                                     </li>
 
@@ -531,7 +531,7 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/community/services/"
+                                                <a href="https://typo3.org/community/services/"
                                                    title="Get an overview about our TYPO3 services for our community (Git, trouble ticketsystems, infrastructure, LDAP, OTRS, Gerrit)."
                                                    class="sub-nav__list-item_link">Services</a>
 
@@ -547,7 +547,7 @@
 
 
                                         <!-- Show all other links -->
-                                        <a href="https://new.typo3.org/certification/"
+                                        <a href="https://typo3.org/certification/"
                                            title="Open menu for Certification"
                                            class="main-nav__list-item_link js__main-nav__list-item_link" data-id="6"
                                            data-level="1" data-sub="1">
@@ -555,7 +555,7 @@
                                         </a>
 
 
-                                        <a href="https://new.typo3.org/certification/"
+                                        <a href="https://typo3.org/certification/"
                                            title="The TYPO3 certification program is a global standard for TYPO3 knowledge. It verifies the knowledge of TYPO3 professionals and their agencies."
                                            class="main-nav__list-item_cross js__main-nav__list-item_cross"> </a>
 
@@ -563,7 +563,7 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/certification/typo3-certifuncation-day/"
+                                                <a href="https://typo3.org/certification/typo3-certifuncation-day/"
                                                    class="sub-nav__list-item_link">TYPO3 CertiFUNcation Day</a>
 
 
@@ -571,12 +571,12 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/certification/editor/"
+                                                <a href="https://typo3.org/certification/editor/"
                                                    title="The TYPO3 CMS Certified Editor can manage pages and content with the various page and content element types provided by integrators."
                                                    class="sub-nav__list-item_link">Certified Editor</a>
 
 
-                                                <a href="https://new.typo3.org/certification/editor/"
+                                                <a href="https://typo3.org/certification/editor/"
                                                    title="The TYPO3 CMS Certified Editor can manage pages and content with the various page and content element types provided by integrators."
                                                    class="main-nav__list-item_cross js__main-nav__list-item_cross">
                                                 </a>
@@ -584,17 +584,17 @@
                                                 <ul class="nav flex-column main-nav__list-item_sub-nav sub-nav__list js__sub-nav__list _lvl-3">
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/certification/editor/syllabus/syllabus-english/"
+                                                        <a href="https://typo3.org/certification/editor/syllabus/syllabus-english/"
                                                            class="sub-nav__list-item_link">Syllabus</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/certification/editor/certified-editor-listing/"
+                                                        <a href="https://typo3.org/certification/editor/certified-editor-listing/"
                                                            class="sub-nav__list-item_link">Certified Editor Listing</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/certification/editor/certification-badges/"
+                                                        <a href="https://typo3.org/certification/editor/certification-badges/"
                                                            class="sub-nav__list-item_link">Certification Badges</a>
                                                     </li>
 
@@ -605,12 +605,12 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/certification/integrator/"
+                                                <a href="https://typo3.org/certification/integrator/"
                                                    title="A TYPO3 CMS Certified Integrator develops the template for a website, configures the necessary extensions and configures access rights for backend users."
                                                    class="sub-nav__list-item_link">Certified Integrator</a>
 
 
-                                                <a href="https://new.typo3.org/certification/integrator/"
+                                                <a href="https://typo3.org/certification/integrator/"
                                                    title="A TYPO3 CMS Certified Integrator develops the template for a website, configures the necessary extensions and configures access rights for backend users."
                                                    class="main-nav__list-item_cross js__main-nav__list-item_cross">
                                                 </a>
@@ -618,7 +618,7 @@
                                                 <ul class="nav flex-column main-nav__list-item_sub-nav sub-nav__list js__sub-nav__list _lvl-3">
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/certification/integrator/syllabus/"
+                                                        <a href="https://typo3.org/certification/integrator/syllabus/"
                                                            class="sub-nav__list-item_link">Syllabus</a>
                                                     </li>
 
@@ -629,12 +629,12 @@
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/certification/integrator/exam-enrollment/"
+                                                        <a href="https://typo3.org/certification/integrator/exam-enrollment/"
                                                            class="sub-nav__list-item_link">Exam enrollment</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/certification/integrator/certification-badges/"
+                                                        <a href="https://typo3.org/certification/integrator/certification-badges/"
                                                            class="sub-nav__list-item_link">Certification Badges</a>
                                                     </li>
 
@@ -645,12 +645,12 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/certification/developer/"
+                                                <a href="https://typo3.org/certification/developer/"
                                                    title="A TYPO3 CMS Certified Developer knows the architecture, design patterns, best practices, of TYPO3 CMS and the extension framework."
                                                    class="sub-nav__list-item_link">Certified Developer</a>
 
 
-                                                <a href="https://new.typo3.org/certification/developer/"
+                                                <a href="https://typo3.org/certification/developer/"
                                                    title="A TYPO3 CMS Certified Developer knows the architecture, design patterns, best practices, of TYPO3 CMS and the extension framework."
                                                    class="main-nav__list-item_cross js__main-nav__list-item_cross">
                                                 </a>
@@ -658,18 +658,18 @@
                                                 <ul class="nav flex-column main-nav__list-item_sub-nav sub-nav__list js__sub-nav__list _lvl-3">
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/certification/developer/syllabus/"
+                                                        <a href="https://typo3.org/certification/developer/syllabus/"
                                                            class="sub-nav__list-item_link">Syllabus</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/certification/developer/certified-developer-listing/"
+                                                        <a href="https://typo3.org/certification/developer/certified-developer-listing/"
                                                            class="sub-nav__list-item_link">Certified Developer
                                                             Listing</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/certification/developer/certification-badges/"
+                                                        <a href="https://typo3.org/certification/developer/certification-badges/"
                                                            class="sub-nav__list-item_link">Certification Badges</a>
                                                     </li>
 
@@ -680,12 +680,12 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/certification/consultant/"
+                                                <a href="https://typo3.org/certification/consultant/"
                                                    title="The TYPO3 CMS Certified Consultant exam is for consultants, project managers, and product owners who advise customers on their TYPO3 projects."
                                                    class="sub-nav__list-item_link">Certified Consultant</a>
 
 
-                                                <a href="https://new.typo3.org/certification/consultant/"
+                                                <a href="https://typo3.org/certification/consultant/"
                                                    title="The TYPO3 CMS Certified Consultant exam is for consultants, project managers, and product owners who advise customers on their TYPO3 projects."
                                                    class="main-nav__list-item_cross js__main-nav__list-item_cross">
                                                 </a>
@@ -693,12 +693,12 @@
                                                 <ul class="nav flex-column main-nav__list-item_sub-nav sub-nav__list js__sub-nav__list _lvl-3">
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/certification/consultant/syllabus/"
+                                                        <a href="https://typo3.org/certification/consultant/syllabus/"
                                                            class="sub-nav__list-item_link">Syllabus</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/certification/consultant/certified-consultant-listing/"
+                                                        <a href="https://typo3.org/certification/consultant/certified-consultant-listing/"
                                                            class="sub-nav__list-item_link">Certified Consultant
                                                             Listing</a>
                                                     </li>
@@ -710,7 +710,7 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/certification/faq/"
+                                                <a href="https://typo3.org/certification/faq/"
                                                    title="Why should I get certified? What do you test? Do I get a refund if I don't pass? Can I take the exam again if I do not pass?"
                                                    class="sub-nav__list-item_link">Frequently Asked Questions</a>
 
@@ -726,14 +726,14 @@
 
 
                                         <!-- Show all other links -->
-                                        <a href="https://new.typo3.org/help/" title="Open menu for Help &amp; Support"
+                                        <a href="https://typo3.org/help/" title="Open menu for Help &amp; Support"
                                            class="main-nav__list-item_link js__main-nav__list-item_link" data-id="28"
                                            data-level="1" data-sub="1">
                                             <span class="">Help &amp; Support</span>
                                         </a>
 
 
-                                        <a href="https://new.typo3.org/help/"
+                                        <a href="https://typo3.org/help/"
                                            title="Ask an editor or developer in the community free help with your TYPO3 questions or pay an agency or freelancer to give you the support you need."
                                            class="main-nav__list-item_cross js__main-nav__list-item_cross"> </a>
 
@@ -767,29 +767,29 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/help/security-bulletins/"
+                                                <a href="https://typo3.org/help/security-bulletins/"
                                                    class="sub-nav__list-item_link">Security
                                                     Bulletins</a>
 
 
-                                                <a href="https://new.typo3.org/help/security-bulletins/"
+                                                <a href="https://typo3.org/help/security-bulletins/"
                                                    class="main-nav__list-item_cross js__main-nav__list-item_cross">
                                                 </a>
 
                                                 <ul class="nav flex-column main-nav__list-item_sub-nav sub-nav__list js__sub-nav__list _lvl-3">
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/help/security-bulletins/typo3-cms/"
+                                                        <a href="https://typo3.org/help/security-bulletins/typo3-cms/"
                                                            class="sub-nav__list-item_link">TYPO3 CMS</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/help/security-bulletins/typo3-extensions/"
+                                                        <a href="https://typo3.org/help/security-bulletins/typo3-extensions/"
                                                            class="sub-nav__list-item_link">TYPO3 Extensions</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/help/security-bulletins/public-service-announcements/"
+                                                        <a href="https://typo3.org/help/security-bulletins/public-service-announcements/"
                                                            class="sub-nav__list-item_link">Public Service
                                                             Announcements</a>
                                                     </li>
@@ -801,12 +801,12 @@
 
 
                                             <li class="list-group-item sub-nav__list-item">
-                                                <a href="https://new.typo3.org/help/documentation/"
+                                                <a href="https://typo3.org/help/documentation/"
                                                    title="TYPO3 CMS has more than ten thousand features. Becoming an expert takes time, but the process will be rewarding. Find your topic of interest or introductions."
                                                    class="sub-nav__list-item_link">Documentation</a>
 
 
-                                                <a href="https://new.typo3.org/help/documentation/"
+                                                <a href="https://typo3.org/help/documentation/"
                                                    title="TYPO3 CMS has more than ten thousand features. Becoming an expert takes time, but the process will be rewarding. Find your topic of interest or introductions."
                                                    class="main-nav__list-item_cross js__main-nav__list-item_cross">
                                                 </a>
@@ -820,12 +820,12 @@
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/help/documentation/video-tutorials/"
+                                                        <a href="https://typo3.org/help/documentation/video-tutorials/"
                                                            class="sub-nav__list-item_link">Video Tutorials</a>
                                                     </li>
 
                                                     <li class="sub-nav__list-item">
-                                                        <a href="https://new.typo3.org/help/documentation/whats-new/"
+                                                        <a href="https://typo3.org/help/documentation/whats-new/"
                                                            class="sub-nav__list-item_link">What's New</a>
                                                     </li>
 
@@ -844,7 +844,7 @@
                                 <ul class="navbar-nav main-nav__list main-nav__meta-nav">
 
                                     <li class="main-nav__meta-nav_item">
-                                        <a href="https://new.typo3.org/cms/download/">
+                                        <a href="https://typo3.org/cms/download/">
 
                                             <img class="main-nav__meta-nav_item-icon img-fluid"
                                                  src="/assets/Gett3o/Assets/TYPO3_installation.svg"
@@ -866,7 +866,7 @@
                                     </li>
 
                                     <li class="main-nav__meta-nav_item">
-                                        <a href="https://new.typo3.org/help/documentation/">
+                                        <a href="https://typo3.org/help/documentation/">
 
                                             <img class="main-nav__meta-nav_item-icon img-fluid"
                                                  src="/assets/Gett3o/Assets/TYPO3_doku.svg"
@@ -892,7 +892,7 @@
 
                             <ul class="list-group sub-nav__list">
                                 <li class="list-group-item sub-nav__list-item _overview">
-                                    <a href="https://new.typo3.org/project/"
+                                    <a href="https://typo3.org/project/"
                                        title="TYPO3 CMS is an open source CMS. The project is international and fully community-driven, and the long-term development is managed by the TYPO3 Association.">
                                         <span>The TYPO3 Project</span>
                                     </a>
@@ -900,7 +900,7 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/project/news/"
+                                    <a href="https://typo3.org/project/news/"
                                        title="Read the latest news about TYPO3 CMS and the association and community supporting the word's most popular enterprise-level content management system."
                                        class="sub-nav__list-item_link">
                                         <span>News</span>
@@ -911,7 +911,7 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/project/products/"
+                                    <a href="https://typo3.org/project/products/"
                                        title="TYPO3 CMS is our most important product. Fluid is a templating engine and Surf a deployment tool. They help deliver groundbreaking technology in TYPO3 CMS."
                                        class="sub-nav__list-item_link">
                                         <span>Our Products</span>
@@ -922,14 +922,14 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/project/association/"
+                                    <a href="https://typo3.org/project/association/"
                                        title="The TYPO3 Association is a not-for-profit membership organization that coordinates and funds the long-term development of the TYPO3 CMS platform."
                                        class="sub-nav__list-item_link">
                                         <span>TYPO3 Association</span>
                                     </a>
 
 
-                                    <a href="https://new.typo3.org/project/association/"
+                                    <a href="https://typo3.org/project/association/"
                                        title="The TYPO3 Association is a not-for-profit membership organization that coordinates and funds the long-term development of the TYPO3 CMS platform."
                                        class="sub-nav__list-item_cross js__sub-nav__list-item_cross" data-id="2"
                                        data-level="2">
@@ -940,14 +940,14 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/project/brand/"
+                                    <a href="https://typo3.org/project/brand/"
                                        title="Find information about how to use the brand and trademark rules, and learn how (not) to spell “TYPO3”."
                                        class="sub-nav__list-item_link">
                                         <span>The Brand</span>
                                     </a>
 
 
-                                    <a href="https://new.typo3.org/project/brand/"
+                                    <a href="https://typo3.org/project/brand/"
                                        title="Find information about how to use the brand and trademark rules, and learn how (not) to spell “TYPO3”."
                                        class="sub-nav__list-item_cross js__sub-nav__list-item_cross" data-id="3"
                                        data-level="2">
@@ -958,7 +958,7 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/project/history/"
+                                    <a href="https://typo3.org/project/history/"
                                        title="TYPO3 was developed from scratch by Kasper Skårhøj in 1997. Separating design and content was a smart solution to an emerging problem."
                                        class="sub-nav__list-item_link">
                                         <span>History</span>
@@ -969,14 +969,14 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/project/press/"
+                                    <a href="https://typo3.org/project/press/"
                                        title="The TYPO3 Association is a not-for-profit organization, founded in 2004 to ensure the long-term development of the web-based content management system TYPO3 CMS."
                                        class="sub-nav__list-item_link">
                                         <span>Press</span>
                                     </a>
 
 
-                                    <a href="https://new.typo3.org/project/press/"
+                                    <a href="https://typo3.org/project/press/"
                                        title="The TYPO3 Association is a not-for-profit organization, founded in 2004 to ensure the long-term development of the web-based content management system TYPO3 CMS."
                                        class="sub-nav__list-item_cross js__sub-nav__list-item_cross" data-id="5"
                                        data-level="2">
@@ -987,7 +987,7 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/project/licenses/"
+                                    <a href="https://typo3.org/project/licenses/"
                                        title="TYPO3 products and extensions use GNU General Public License, where you are allowed to sell the extension as long as you do not change the license terms."
                                        class="sub-nav__list-item_link">
                                         <span>Licenses</span>
@@ -998,7 +998,7 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/project/technology-supporters/"
+                                    <a href="https://typo3.org/project/technology-supporters/"
                                        title="This section is dedicated to our supporters offering their tools and services for free in the scope of open source software."
                                        class="sub-nav__list-item_link">
                                         <span>Technology Supporters</span>
@@ -1014,52 +1014,52 @@
                                 data-parent-lvl2="2">
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/project/association/membership/"
+                                    <a href="https://typo3.org/project/association/membership/"
                                        title="Members of the TYPO3 Association support the development of TYPO3 CMS and take part in shaping the future of TYPO3 CMS."
                                        data-level="3">Become a Member</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/project/association/members/"
+                                    <a href="https://typo3.org/project/association/members/"
                                        title="This is a list of personal and organizational members of the TYPO3 Association."
                                        data-level="3">Our Members</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/project/association/structure/"
+                                    <a href="https://typo3.org/project/association/structure/"
                                        title="The TYPO3 Association has four main bodies: the General Assembly, the Board, the Expert Advisory Board (EAB), and the Business Control Committee (BCC)."
                                        data-level="3">Structure</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/project/association/funding-finances/"
+                                    <a href="https://typo3.org/project/association/funding-finances/"
                                        title="Most of the Association's income comes from membership fees, donations, and events. €650,000 is funneled back into core development and community projects."
                                        data-level="3">Funding &amp; Finances</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/project/association/structure/general-assembly/"
+                                    <a href="https://typo3.org/project/association/structure/general-assembly/"
                                        data-level="3">General
                                         Assembly</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/project/association/association-projects/"
+                                    <a href="https://typo3.org/project/association/association-projects/"
                                        data-level="3">Association
                                         Projects</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/project/association/partnerships/" data-level="3">Partnerships</a>
+                                    <a href="https://typo3.org/project/association/partnerships/" data-level="3">Partnerships</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/project/association/by-laws/"
+                                    <a href="https://typo3.org/project/association/by-laws/"
                                        data-level="3">By-Laws</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/project/association/contact/"
+                                    <a href="https://typo3.org/project/association/contact/"
                                        title="For general enquiries, coordination, community involvement and sponsorship feel free to contact: info@typo3.org"
                                        data-level="3">Contact</a>
                                 </li>
@@ -1071,23 +1071,23 @@
                                 data-parent-lvl2="3">
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/project/brand/trademarks/"
+                                    <a href="https://typo3.org/project/brand/trademarks/"
                                        title="The word “TYPO3” is one of the trademarks owned by the TYPO3 Association. We have created guidelines to help people understand what is (and is not) OK."
                                        data-level="3">Trademarks</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/project/brand/style-guide/" data-level="3">Style
+                                    <a href="https://typo3.org/project/brand/style-guide/" data-level="3">Style
                                         Guide</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/project/brand/typo3-slidedeck/" data-level="3">TYPO3
+                                    <a href="https://typo3.org/project/brand/typo3-slidedeck/" data-level="3">TYPO3
                                         slidedeck</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/project/brand/spelling-typo3/"
+                                    <a href="https://typo3.org/project/brand/spelling-typo3/"
                                        title="TYPO3 is always written in uppercase, with no spaces. This rule covers all products under the TYPO3 project. URLs are the only exception to this rule."
                                        data-level="3">Spelling TYPO3</a>
                                 </li>
@@ -1099,12 +1099,12 @@
                                 data-parent-lvl2="5">
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/project/press/press-releases/" data-level="3">Press
+                                    <a href="https://typo3.org/project/press/press-releases/" data-level="3">Press
                                         Releases</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/project/press/press-photos/" data-level="3">Press
+                                    <a href="https://typo3.org/project/press/press-photos/" data-level="3">Press
                                         Photos</a>
                                 </li>
 
@@ -1114,7 +1114,7 @@
                             <div class="teaser-box sub-nav__media">
 
                                 <img class="teaser-box__img-top img-fluid"
-                                     src="https://new.typo3.org/fileadmin/_processed_/a/5/csm_26276623101_a436d2f07a_o_270a7b2c42.jpg"
+                                     src="https://typo3.org/fileadmin/_processed_/a/5/csm_26276623101_a436d2f07a_o_270a7b2c42.jpg"
                                      width="390" height="260" alt="">
 
 
@@ -1143,7 +1143,7 @@
 
                             <ul class="list-group sub-nav__list">
                                 <li class="list-group-item sub-nav__list-item _overview">
-                                    <a href="https://new.typo3.org/cms/"
+                                    <a href="https://typo3.org/cms/"
                                        title="Free and open source, TYPO3 CMS is a leading content management system with a&nbsp;feature set&nbsp;eclipsing that of our commercial and proprietary competitors.">
                                         <span>Overview</span>
                                     </a>
@@ -1151,7 +1151,7 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/cms/features/"
+                                    <a href="https://typo3.org/cms/features/"
                                        title="TYPO3 CMS has thousands of features. This page gives a comprehensive, but far from complete, overview."
                                        class="sub-nav__list-item_link">
                                         <span>Features</span>
@@ -1171,14 +1171,14 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/cms/roadmap/"
+                                    <a href="https://typo3.org/cms/roadmap/"
                                        title="The TYPO3 CMS development roadmap follows an 18-month release cycle for Long Term Support versions."
                                        class="sub-nav__list-item_link">
                                         <span>Roadmap</span>
                                     </a>
 
 
-                                    <a href="https://new.typo3.org/cms/roadmap/"
+                                    <a href="https://typo3.org/cms/roadmap/"
                                        title="The TYPO3 CMS development roadmap follows an 18-month release cycle for Long Term Support versions."
                                        class="sub-nav__list-item_cross js__sub-nav__list-item_cross" data-id="2"
                                        data-level="2">
@@ -1189,7 +1189,7 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/help/documentation/" class="sub-nav__list-item_link">
+                                    <a href="https://typo3.org/help/documentation/" class="sub-nav__list-item_link">
                                         <span>Documentation</span>
                                     </a>
 
@@ -1198,7 +1198,7 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/cms/requirements/"
+                                    <a href="https://typo3.org/cms/requirements/"
                                        title="It doesn't take a degree in engineering to get TYPO3 up an running. Find the facts and figures you need to get started with your first project."
                                        class="sub-nav__list-item_link">
                                         <span>System Requirements</span>
@@ -1225,18 +1225,18 @@
                                 data-parent-lvl2="2">
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/cms/roadmap/release-news/" data-level="3">Release
+                                    <a href="https://typo3.org/cms/roadmap/release-news/" data-level="3">Release
                                         News</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/cms/roadmap/typo3-8-release-notes/" data-level="3">TYPO3
+                                    <a href="https://typo3.org/cms/roadmap/typo3-8-release-notes/" data-level="3">TYPO3
                                         8 Release
                                         Notes</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/cms/roadmap/typo3-7-release-notes/" data-level="3">TYPO3
+                                    <a href="https://typo3.org/cms/roadmap/typo3-7-release-notes/" data-level="3">TYPO3
                                         7 Release
                                         Notes</a>
                                 </li>
@@ -1247,7 +1247,7 @@
                             <div class="teaser-box sub-nav__media">
 
                                 <img class="teaser-box__img-top img-fluid"
-                                     src="https://new.typo3.org/fileadmin/_processed_/b/2/csm_typo3-pagetree-screenshot-mock-up_984f8f3795.jpg"
+                                     src="https://typo3.org/fileadmin/_processed_/b/2/csm_typo3-pagetree-screenshot-mock-up_984f8f3795.jpg"
                                      width="480" height="257" alt="">
 
 
@@ -1275,7 +1275,7 @@
 
                             <ul class="list-group sub-nav__list">
                                 <li class="list-group-item sub-nav__list-item _overview">
-                                    <a href="https://new.typo3.org/community/"
+                                    <a href="https://typo3.org/community/"
                                        title="The TYPO3 Community is growing, and we do&nbsp;more than just developing software.&nbsp;Everyone is welcome. Offer your skills and contribute to TYPO3.">
                                         <span>Community</span>
                                     </a>
@@ -1283,7 +1283,7 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/community/events/"
+                                    <a href="https://typo3.org/community/events/"
                                        title="There are quite some TYPO3 events during the year. You can take part in official events organized by the TYPO3 Association and events organized by the TYPO3 community."
                                        class="sub-nav__list-item_link">
                                         <span>Events</span>
@@ -1294,14 +1294,14 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/community/meet/"
+                                    <a href="https://typo3.org/community/meet/"
                                        title="Online, at events, or in user groups. There are many ways to meet us."
                                        class="sub-nav__list-item_link">
                                         <span>Meet the Community</span>
                                     </a>
 
 
-                                    <a href="https://new.typo3.org/community/meet/"
+                                    <a href="https://typo3.org/community/meet/"
                                        title="Online, at events, or in user groups. There are many ways to meet us."
                                        class="sub-nav__list-item_cross js__sub-nav__list-item_cross" data-id="1"
                                        data-level="2">
@@ -1312,13 +1312,13 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/community/contribute/"
+                                    <a href="https://typo3.org/community/contribute/"
                                        class="sub-nav__list-item_link">
                                         <span>Contribute / Get Involved</span>
                                     </a>
 
 
-                                    <a href="https://new.typo3.org/community/contribute/"
+                                    <a href="https://typo3.org/community/contribute/"
                                        class="sub-nav__list-item_cross js__sub-nav__list-item_cross" data-id="2"
                                        data-level="2">
                                         <span>+</span>
@@ -1328,14 +1328,14 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/community/teams/"
+                                    <a href="https://typo3.org/community/teams/"
                                        title="The teams and committees of the TYPO3 community take on tasks within specific areas, such as core development, education, communication and security."
                                        class="sub-nav__list-item_link">
                                         <span>Teams &amp; Committees</span>
                                     </a>
 
 
-                                    <a href="https://new.typo3.org/community/teams/"
+                                    <a href="https://typo3.org/community/teams/"
                                        title="The teams and committees of the TYPO3 community take on tasks within specific areas, such as core development, education, communication and security."
                                        class="sub-nav__list-item_cross js__sub-nav__list-item_cross" data-id="3"
                                        data-level="2">
@@ -1346,14 +1346,14 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/community/values/"
+                                    <a href="https://typo3.org/community/values/"
                                        title="TYPO3 is more than just a piece of software. It is a community. Our values guide our work and make sure the community is a great place for everyone."
                                        class="sub-nav__list-item_link">
                                         <span>Our Values</span>
                                     </a>
 
 
-                                    <a href="https://new.typo3.org/community/values/"
+                                    <a href="https://typo3.org/community/values/"
                                        title="TYPO3 is more than just a piece of software. It is a community. Our values guide our work and make sure the community is a great place for everyone."
                                        class="sub-nav__list-item_cross js__sub-nav__list-item_cross" data-id="4"
                                        data-level="2">
@@ -1364,7 +1364,7 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/community/services/"
+                                    <a href="https://typo3.org/community/services/"
                                        title="Get an overview about our TYPO3 services for our community (Git, trouble ticketsystems, infrastructure, LDAP, OTRS, Gerrit)."
                                        class="sub-nav__list-item_link">
                                         <span>Services</span>
@@ -1380,7 +1380,7 @@
                                 data-parent-lvl2="1">
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/community/meet/user-groups/"
+                                    <a href="https://typo3.org/community/meet/user-groups/"
                                        title="Many users would like to get in personal contact with other TYPO3 enthusiasts. This is how local TYPO3 User Groups (TUG) are formed."
                                        data-level="3">User Groups</a>
                                 </li>
@@ -1392,13 +1392,13 @@
                                 data-parent-lvl2="2">
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/project/association/membership/" data-level="3">Become
+                                    <a href="https://typo3.org/project/association/membership/" data-level="3">Become
                                         an Association
                                         Member</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/community/contribute/donate/"
+                                    <a href="https://typo3.org/community/contribute/donate/"
                                        title="TYPO3 is an Open Source project, dependent in large parts on donations. This page is for those who want to donate money"
                                        data-level="3">Donate</a>
                                 </li>
@@ -1410,19 +1410,19 @@
                                 data-parent-lvl2="3">
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/community/teams/typo3-development/"
+                                    <a href="https://typo3.org/community/teams/typo3-development/"
                                        title="The TYPO3 Core Development Team is dedicated to develop and maintain the central parts of TYPO3 CMS."
                                        data-level="3">TYPO3 Development</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/community/teams/communication/"
+                                    <a href="https://typo3.org/community/teams/communication/"
                                        title="The Communication Group coordinates and produces press releases, media statements, articles, and press workflow for all TYPO3 teams."
                                        data-level="3">Communication</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/community/teams/typo3org/"
+                                    <a href="https://typo3.org/community/teams/typo3org/"
                                        title="The typo3.org team develops and maintains the typo3.org website, the Extension Repository, Events&nbsp;and Certification Listings, and much more."
                                        data-level="3">typo3.org</a>
                                 </li>
@@ -1434,25 +1434,25 @@
                                 data-parent-lvl2="4">
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/community/values/code-of-conduct/"
+                                    <a href="https://typo3.org/community/values/code-of-conduct/"
                                        title="The vision of our project is &quot;Inspiring people to share&quot;. This motto is central to the way the TYPO3 community collaborates."
                                        data-level="3">Code of Conduct</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/community/values/leadership-code-of-conduct/"
+                                    <a href="https://typo3.org/community/values/leadership-code-of-conduct/"
                                        title="This document provides a set of guidelines and explains to all members the high standards of conduct that leaders in the TYPO3 community should be held."
                                        data-level="3">Leadership Code of Conduct</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/community/values/event-code-of-conduct/"
+                                    <a href="https://typo3.org/community/values/event-code-of-conduct/"
                                        title="We don't condone harassment or offensive behavior, at our event venues or anywhere. It's counter to our community values."
                                        data-level="3">Event Code of Conduct</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/community/values/social-media-guidelines/"
+                                    <a href="https://typo3.org/community/values/social-media-guidelines/"
                                        title="These are the official guidelines for participating in social media for the TYPO3 Project."
                                        data-level="3">Social Media Guidelines</a>
                                 </li>
@@ -1463,7 +1463,7 @@
                             <div class="teaser-box sub-nav__media">
 
                                 <img class="teaser-box__img-top img-fluid"
-                                     src="https://new.typo3.org/fileadmin/_processed_/0/8/csm_6932872980_d788451b65_o_4e84bb9425.jpg"
+                                     src="https://typo3.org/fileadmin/_processed_/0/8/csm_6932872980_d788451b65_o_4e84bb9425.jpg"
                                      width="480" height="154" alt="">
 
 
@@ -1475,7 +1475,7 @@
 
 
                                         <p>Offer your skills and&nbsp;<a
-                                                    href="https://new.typo3.org/community/contribute-get-involved/"
+                                                    href="https://typo3.org/community/contribute-get-involved/"
                                                     target="_blank" rel="noopener">contribute to the project</a>.&nbsp;The community is
                                             growing&nbsp;and does more than just coding.&nbsp;</p>
 
@@ -1494,7 +1494,7 @@
 
                             <ul class="list-group sub-nav__list">
                                 <li class="list-group-item sub-nav__list-item _overview">
-                                    <a href="https://new.typo3.org/certification/"
+                                    <a href="https://typo3.org/certification/"
                                        title="The TYPO3 certification program is a global standard for TYPO3 knowledge. It verifies the knowledge of TYPO3 professionals and their agencies.">
                                         <span>Certification</span>
                                     </a>
@@ -1502,7 +1502,7 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/certification/typo3-certifuncation-day/"
+                                    <a href="https://typo3.org/certification/typo3-certifuncation-day/"
                                        class="sub-nav__list-item_link">
                                         <span>TYPO3 CertiFUNcation Day</span>
                                     </a>
@@ -1512,14 +1512,14 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/certification/editor/"
+                                    <a href="https://typo3.org/certification/editor/"
                                        title="The TYPO3 CMS Certified Editor can manage pages and content with the various page and content element types provided by integrators."
                                        class="sub-nav__list-item_link">
                                         <span>Certified Editor</span>
                                     </a>
 
 
-                                    <a href="https://new.typo3.org/certification/editor/"
+                                    <a href="https://typo3.org/certification/editor/"
                                        title="The TYPO3 CMS Certified Editor can manage pages and content with the various page and content element types provided by integrators."
                                        class="sub-nav__list-item_cross js__sub-nav__list-item_cross" data-id="1"
                                        data-level="2">
@@ -1530,14 +1530,14 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/certification/integrator/"
+                                    <a href="https://typo3.org/certification/integrator/"
                                        title="A TYPO3 CMS Certified Integrator develops the template for a website, configures the necessary extensions and configures access rights for backend users."
                                        class="sub-nav__list-item_link">
                                         <span>Certified Integrator</span>
                                     </a>
 
 
-                                    <a href="https://new.typo3.org/certification/integrator/"
+                                    <a href="https://typo3.org/certification/integrator/"
                                        title="A TYPO3 CMS Certified Integrator develops the template for a website, configures the necessary extensions and configures access rights for backend users."
                                        class="sub-nav__list-item_cross js__sub-nav__list-item_cross" data-id="2"
                                        data-level="2">
@@ -1548,14 +1548,14 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/certification/developer/"
+                                    <a href="https://typo3.org/certification/developer/"
                                        title="A TYPO3 CMS Certified Developer knows the architecture, design patterns, best practices, of TYPO3 CMS and the extension framework."
                                        class="sub-nav__list-item_link">
                                         <span>Certified Developer</span>
                                     </a>
 
 
-                                    <a href="https://new.typo3.org/certification/developer/"
+                                    <a href="https://typo3.org/certification/developer/"
                                        title="A TYPO3 CMS Certified Developer knows the architecture, design patterns, best practices, of TYPO3 CMS and the extension framework."
                                        class="sub-nav__list-item_cross js__sub-nav__list-item_cross" data-id="3"
                                        data-level="2">
@@ -1566,14 +1566,14 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/certification/consultant/"
+                                    <a href="https://typo3.org/certification/consultant/"
                                        title="The TYPO3 CMS Certified Consultant exam is for consultants, project managers, and product owners who advise customers on their TYPO3 projects."
                                        class="sub-nav__list-item_link">
                                         <span>Certified Consultant</span>
                                     </a>
 
 
-                                    <a href="https://new.typo3.org/certification/consultant/"
+                                    <a href="https://typo3.org/certification/consultant/"
                                        title="The TYPO3 CMS Certified Consultant exam is for consultants, project managers, and product owners who advise customers on their TYPO3 projects."
                                        class="sub-nav__list-item_cross js__sub-nav__list-item_cross" data-id="4"
                                        data-level="2">
@@ -1584,7 +1584,7 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/certification/faq/"
+                                    <a href="https://typo3.org/certification/faq/"
                                        title="Why should I get certified? What do you test? Do I get a refund if I don't pass? Can I take the exam again if I do not pass?"
                                        class="sub-nav__list-item_link">
                                         <span>Frequently Asked Questions</span>
@@ -1600,18 +1600,18 @@
                                 data-parent-lvl2="1">
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/certification/editor/syllabus/syllabus-english/"
+                                    <a href="https://typo3.org/certification/editor/syllabus/syllabus-english/"
                                        data-level="3">Syllabus</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/certification/editor/certified-editor-listing/"
+                                    <a href="https://typo3.org/certification/editor/certified-editor-listing/"
                                        data-level="3">Certified
                                         Editor Listing</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/certification/editor/certification-badges/"
+                                    <a href="https://typo3.org/certification/editor/certification-badges/"
                                        data-level="3">Certification
                                         Badges</a>
                                 </li>
@@ -1623,7 +1623,7 @@
                                 data-parent-lvl2="2">
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/certification/integrator/syllabus/" data-level="3">Syllabus</a>
+                                    <a href="https://typo3.org/certification/integrator/syllabus/" data-level="3">Syllabus</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
@@ -1632,13 +1632,13 @@
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/certification/integrator/exam-enrollment/"
+                                    <a href="https://typo3.org/certification/integrator/exam-enrollment/"
                                        data-level="3">Exam
                                         enrollment</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/certification/integrator/certification-badges/"
+                                    <a href="https://typo3.org/certification/integrator/certification-badges/"
                                        data-level="3">Certification
                                         Badges</a>
                                 </li>
@@ -1650,17 +1650,17 @@
                                 data-parent-lvl2="3">
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/certification/developer/syllabus/" data-level="3">Syllabus</a>
+                                    <a href="https://typo3.org/certification/developer/syllabus/" data-level="3">Syllabus</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/certification/developer/certified-developer-listing/"
+                                    <a href="https://typo3.org/certification/developer/certified-developer-listing/"
                                        data-level="3">Certified
                                         Developer Listing</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/certification/developer/certification-badges/"
+                                    <a href="https://typo3.org/certification/developer/certification-badges/"
                                        data-level="3">Certification
                                         Badges</a>
                                 </li>
@@ -1672,11 +1672,11 @@
                                 data-parent-lvl2="4">
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/certification/consultant/syllabus/" data-level="3">Syllabus</a>
+                                    <a href="https://typo3.org/certification/consultant/syllabus/" data-level="3">Syllabus</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/certification/consultant/certified-consultant-listing/"
+                                    <a href="https://typo3.org/certification/consultant/certified-consultant-listing/"
                                        data-level="3">Certified
                                         Consultant Listing</a>
                                 </li>
@@ -1687,7 +1687,7 @@
                             <div class="teaser-box sub-nav__media">
 
                                 <img class="teaser-box__img-top img-fluid"
-                                     src="https://new.typo3.org/fileadmin/_processed_/e/1/csm_stopwatch_37854931c8.jpg"
+                                     src="https://typo3.org/fileadmin/_processed_/e/1/csm_stopwatch_37854931c8.jpg"
                                      width="390"
                                      height="260" alt="">
 
@@ -1717,7 +1717,7 @@
 
                             <ul class="list-group sub-nav__list">
                                 <li class="list-group-item sub-nav__list-item _overview">
-                                    <a href="https://new.typo3.org/help/"
+                                    <a href="https://typo3.org/help/"
                                        title="Ask an editor or developer in the community free help with your TYPO3 questions or pay an agency or freelancer to give you the support you need.">
                                         <span>Getting Help &amp; Support</span>
                                     </a>
@@ -1754,13 +1754,13 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/help/security-bulletins/"
+                                    <a href="https://typo3.org/help/security-bulletins/"
                                        class="sub-nav__list-item_link">
                                         <span>Security Bulletins</span>
                                     </a>
 
 
-                                    <a href="https://new.typo3.org/help/security-bulletins/"
+                                    <a href="https://typo3.org/help/security-bulletins/"
                                        class="sub-nav__list-item_cross js__sub-nav__list-item_cross" data-id="3"
                                        data-level="2">
                                         <span>+</span>
@@ -1770,14 +1770,14 @@
 
                                 <li class="list-group-item sub-nav__list-item js__sub-nav__list-item _lvl2">
 
-                                    <a href="https://new.typo3.org/help/documentation/"
+                                    <a href="https://typo3.org/help/documentation/"
                                        title="TYPO3 CMS has more than ten thousand features. Becoming an expert takes time, but the process will be rewarding. Find your topic of interest or introductions."
                                        class="sub-nav__list-item_link">
                                         <span>Documentation</span>
                                     </a>
 
 
-                                    <a href="https://new.typo3.org/help/documentation/"
+                                    <a href="https://typo3.org/help/documentation/"
                                        title="TYPO3 CMS has more than ten thousand features. Becoming an expert takes time, but the process will be rewarding. Find your topic of interest or introductions."
                                        class="sub-nav__list-item_cross js__sub-nav__list-item_cross" data-id="4"
                                        data-level="2">
@@ -1793,18 +1793,18 @@
                                 data-parent-lvl2="3">
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/help/security-bulletins/typo3-cms/" data-level="3">TYPO3
+                                    <a href="https://typo3.org/help/security-bulletins/typo3-cms/" data-level="3">TYPO3
                                         CMS</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/help/security-bulletins/typo3-extensions/"
+                                    <a href="https://typo3.org/help/security-bulletins/typo3-extensions/"
                                        data-level="3">TYPO3
                                         Extensions</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/help/security-bulletins/public-service-announcements/"
+                                    <a href="https://typo3.org/help/security-bulletins/public-service-announcements/"
                                        data-level="3">Public
                                         Service Announcements</a>
                                 </li>
@@ -1821,12 +1821,12 @@
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/help/documentation/video-tutorials/" data-level="3">Video
+                                    <a href="https://typo3.org/help/documentation/video-tutorials/" data-level="3">Video
                                         Tutorials</a>
                                 </li>
 
                                 <li class="list-group-item lvl3">
-                                    <a href="https://new.typo3.org/help/documentation/whats-new/" data-level="3">What's
+                                    <a href="https://typo3.org/help/documentation/whats-new/" data-level="3">What's
                                         New</a>
                                 </li>
 
@@ -1836,7 +1836,7 @@
                             <div class="teaser-box sub-nav__media">
 
                                 <img class="teaser-box__img-top img-fluid"
-                                     src="https://new.typo3.org/fileadmin/_processed_/d/5/csm_startup-photos_3680a49e5f.jpg"
+                                     src="https://typo3.org/fileadmin/_processed_/d/5/csm_startup-photos_3680a49e5f.jpg"
                                      width="390"
                                      height="260" alt="">
 
@@ -1869,12 +1869,12 @@
                              data-parent-lvl1="229">
                             <div class="d-flex flex-row m-auto">
 
-                                <form action="https://new.typo3.org/" onsubmit="return true;" method="post">
+                                <form action="https://typo3.org/" onsubmit="return true;" method="post">
                                     <div class="hidden">
                                         <input type="hidden" name="logintype" value="login">
                                         <input type="hidden" name="pid" value="178">
                                         <input type="hidden" name="redirect_url"
-                                               value="?eID=FlyOutAjaxLoginController&amp;returnUrl=https%3A%2F%2Fnew.typo3.org%2F&amp;cHash=6bb59831b32fd80e161c9f98f6d1a1b8">
+                                               value="?eID=FlyOutAjaxLoginController&amp;returnUrl=https%3A%2F%2Ftypo3.org%2F&amp;cHash=6bb59831b32fd80e161c9f98f6d1a1b8">
                                     </div>
                                     <h4>Enter your credentials below to sign in</h4>
                                     <div class="form-control__wrp">


### PR DESCRIPTION
Since the new typo3.org website is live now, all links to the subdomain
new.typo3.org should now link to typo3.org