### PR TITLE
[TASK] Remove typo3/cms-felogin from typo3/default

### DIFF
--- a/src/Service/ComposerPackagesService.php
+++ b/src/Service/ComposerPackagesService.php
@@ -230,7 +230,6 @@ class ComposerPackagesService
             'typo3/cms-beuser',
             'typo3/cms-core',
             'typo3/cms-extbase',
-            'typo3/cms-felogin',
             'typo3/cms-filelist',
             'typo3/cms-fluid',
             'typo3/cms-fluid-styled-content',


### PR DESCRIPTION
 The frontend login should not be part of the default package.
I think 90% of the TYPO3 instances don't need the fronted login.