### PR TITLE
[TASK] Update wording about TYPO3 releases at AWS

### DIFF
--- a/templates/default/show.html.twig
+++ b/templates/default/show.html.twig
@@ -130,15 +130,14 @@
                      alt="AWS">
                 <div class="card-body">
                     <p class="card-text">Debian GNU/Linux based machine images are available on Amazon Web
-                        Services (AWS). A „root“
-                        login via SSH and an administrator account to the backend allow unrestricted access to
-                        the server and
-                        TYPO3. TYPO3 v7, v8 and 9.x sprint releases are available.
+                        Services (AWS). A &quot;root&quot; login via SSH and an administrator account to the
+                        TYPO3 backend allow unrestricted access to the server and CMS. TYPO3 v7, v8 and v9 LTS
+                        releases are available.
                     </p>
                 </div>
                 <div class="card-footer border-top-0">
                     <a href="https://aws.amazon.com/marketplace/seller-profile/?id=3c5e5f3c-d60e-4405-a9ca-aae8abfa3e2b"
-                       class="btn btn-primary btn-block b_btn--version">Go to AWS</a>
+                       class="btn btn-primary btn-block b_btn--version">Go to AWS Marketplace</a>
                 </div>
             </div>
             <div class="card card-padding">


### PR DESCRIPTION
This change updates the text in the AWS info box.  
I assume, only the Twig template file needs to be updated (not the file under `legacy/`).

Resolves #34