### PR TITLE
[BUGFIX] Do not dispatch "submit" event on composer-helper form

### DIFF
--- a/public/assets/JavaScript/composerHelper.js
+++ b/public/assets/JavaScript/composerHelper.js
@@ -115,8 +115,7 @@ const vanillaAjaxForm = function(form) {
  */
 const checkboxChangeEvent = function() {
     const form = document.getElementById('js-composer-helper-form');
-    const event = new Event('submit');
-    form.dispatchEvent(event);
+    vanillaAjaxForm(form);
 };
 
 const copyCommandToClipboard = function() {


### PR DESCRIPTION
Forcing a form "submit" bypasses the XMLHttpRequest in Firefox 67 and newer versions which opens the JSON Ajax response in a window rather than providing the data in xhr.responseText.

This fix executes the Ajax function directly instead of dispatching the "submit" event on the composer-helper form.

➜ **Please review and test the patch in various browsers if possible.**

Resolves #40