### PR TITLE
[BUGFIX] Use latest base distribution

### DIFF
--- a/templates/default/partials/download-area.html.twig
+++ b/templates/default/partials/download-area.html.twig
@@ -42,7 +42,7 @@
                 </a>
                 <div id="downloadComposer" class="collapse" role="tabpanel">
                     <div class="b_accordion__content">
-                        <pre>composer create-project typo3/cms-base-distribution my-new-project {{ lts }}</pre>
+                        <pre>composer create-project typo3/cms-base-distribution my-new-project ^{{ lts }}</pre>
                         <p>If you are experienced with composer you can create your own composer.json and select the needed packages of TYPO3 via this helper: <a href="https://get.typo3.org/misc/composer/helper" title="Composer helper">get.typo3.org/misc/composer/helper</a></p>
                     </div>
                 </div>

--- a/templates/default/partials/download-area.html.twig
+++ b/templates/default/partials/download-area.html.twig
@@ -42,7 +42,11 @@
                 </a>
                 <div id="downloadComposer" class="collapse" role="tabpanel">
                     <div class="b_accordion__content">
-                        <pre>composer create-project typo3/cms-base-distribution my-new-project ^{{ lts }}</pre>
+                        {% if lts %}
+                            <pre>composer create-project typo3/cms-base-distribution my-new-project ^{{ lts }}</pre>
+                        {% else %}
+                            <pre>composer create-project typo3/cms-base-distribution my-new-project</pre>
+                        {% endif %}
                         <p>If you are experienced with composer you can create your own composer.json and select the needed packages of TYPO3 via this helper: <a href="https://get.typo3.org/misc/composer/helper" title="Composer helper">get.typo3.org/misc/composer/helper</a></p>
                     </div>
                 </div>


### PR DESCRIPTION
In case of v8.7 e.g. there are multiple versions of the cms base distribution. Without the `^` prefix the new project is always created from version 8.7.0 and not the latest 8.7.2.