### PR TITLE
[TASK] Update wording and brand name "GitHub"

### DIFF
--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -1961,12 +1961,12 @@
         <div class="d-flex justify-content-between flex-wrap align-items-center">
             <div class="infoBannerBottom-left">
                 <p>
-                    Want to contribute to this website or report feedback?
+                    Do you want to contribute to this website or report feedback?
                 </p>
             </div>
             <div class="infoBannerBottom-right">
                 <a class="btn btn-primary pull-right" href="https://github.com/TYPO3-infrastructure/get.typo3.org/issues" target="_blank" rel="noopener">
-                    Go to our github repository
+                    Go to our GitHub repository
                 </a>
             </div>
         </div>


### PR DESCRIPTION
Wording in the infoBannerBottom slightly updated and brand name GitHub spelled correctly.

Resolves #52