### PR TITLE
Add elts bool to release

### DIFF
--- a/src/Entity/MajorVersion.php
+++ b/src/Entity/MajorVersion.php
@@ -127,16 +127,14 @@ class MajorVersion implements \JsonSerializable
         return $this->version;
     }
 
+    public function setReleases(Collection $releases): void
+    {
+        $this->releases = $releases;
+    }
+
     public function getReleases(): Collection
     {
         return $this->releases;
-    }
-
-    public function removeEltsReleases(): void
-    {
-        $this->releases = $this->releases->filter(static function (Release $release) {
-            return !$release->isElts();
-        });
     }
 
     public function getTitle(): string

--- a/src/Entity/MajorVersion.php
+++ b/src/Entity/MajorVersion.php
@@ -132,6 +132,13 @@ class MajorVersion implements \JsonSerializable
         return $this->releases;
     }
 
+    public function getReleasesWithoutElts(): Collection
+    {
+        return $this->releases->filter(static function (Release $release) {
+            return !$release->isElts();
+        });
+    }
+
     public function getTitle(): string
     {
         return $this->title;

--- a/src/Entity/MajorVersion.php
+++ b/src/Entity/MajorVersion.php
@@ -132,9 +132,9 @@ class MajorVersion implements \JsonSerializable
         return $this->releases;
     }
 
-    public function getReleasesWithoutElts(): Collection
+    public function removeEltsReleases(): void
     {
-        return $this->releases->filter(static function (Release $release) {
+        $this->releases = $this->releases->filter(static function (Release $release) {
             return !$release->isElts();
         });
     }

--- a/src/Entity/Release.php
+++ b/src/Entity/Release.php
@@ -90,6 +90,20 @@ class Release implements \JsonSerializable
     private $releaseNotes;
 
     /**
+     * @ORM\Column(type="boolean")
+     * @ORM\Column(options={"default": 0})
+     * @var bool
+     * @Serializer\Groups({"data", "content"})
+     * @Assert\Valid
+     */
+    private $elts;
+
+    public function __construct()
+    {
+        $this->elts = false;
+    }
+
+    /**
      * @return string
      */
     public function getVersion(): string
@@ -138,6 +152,16 @@ class Release implements \JsonSerializable
     public function getType(): string
     {
         return $this->type;
+    }
+
+    public function setElts(bool $elts): void
+    {
+        $this->elts = $elts;
+    }
+
+    public function isElts(): bool
+    {
+        return $this->elts;
     }
 
     /**

--- a/src/Entity/Release.php
+++ b/src/Entity/Release.php
@@ -54,6 +54,16 @@ class Release implements \JsonSerializable
     private $type;
 
     /**
+     * @ORM\Column(type="boolean")
+     * @ORM\Column(options={"default": 0})
+     * @var bool
+     * @Serializer\Groups({"data", "content"})
+     * @Assert\Valid
+     * @SWG\Property(example="true")
+     */
+    private $elts;
+
+    /**
      * @ORM\Embedded(class = "App\Entity\Embeddables\Package")
      * @var Package
      * @Serializer\Type("App\Entity\Embeddables\Package")
@@ -88,15 +98,6 @@ class Release implements \JsonSerializable
      * @Assert\Valid
      */
     private $releaseNotes;
-
-    /**
-     * @ORM\Column(type="boolean")
-     * @ORM\Column(options={"default": 0})
-     * @var bool
-     * @Serializer\Groups({"data", "content"})
-     * @Assert\Valid
-     */
-    private $elts;
 
     public function __construct()
     {

--- a/src/Entity/Release.php
+++ b/src/Entity/Release.php
@@ -58,7 +58,7 @@ class Release implements \JsonSerializable
      * @ORM\Column(options={"default": 0})
      * @var bool
      * @Serializer\Groups({"data", "content"})
-     * @Assert\Valid
+     * @Assert\Type("boolean")
      * @SWG\Property(example="true")
      */
     private $elts;

--- a/src/Migrations/Version20180324140648.php
+++ b/src/Migrations/Version20180324140648.php
@@ -9,15 +9,15 @@
 
 namespace DoctrineMigrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
 
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
 class Version20180324140648 extends AbstractMigration
 {
-    public function up(Schema $schema)
+    public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'sqlite', 'Migration can only be executed safely on \'sqlite\'.');
@@ -31,7 +31,7 @@ class Version20180324140648 extends AbstractMigration
         $this->addSql('CREATE INDEX IDX_DB3F5550BF1CD3C3 ON requirement (version)');
     }
 
-    public function down(Schema $schema)
+    public function down(Schema $schema): void
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'sqlite', 'Migration can only be executed safely on \'sqlite\'.');

--- a/src/Migrations/Version20191112143111.php
+++ b/src/Migrations/Version20191112143111.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package t3o/gettypo3org.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20191112143111 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Add ELTS bool to releases';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'sqlite', 'Migration can only be executed safely on \'sqlite\'.');
+
+        $this->addSql('ALTER TABLE release ADD COLUMN elts BOOLEAN DEFAULT \'0\' NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'sqlite', 'Migration can only be executed safely on \'sqlite\'.');
+
+        $this->addSql('DROP INDEX IDX_9E47031D17E84B00');
+        $this->addSql('CREATE TEMPORARY TABLE __temp__release AS SELECT version, major_version, date, type, tar_package_md5sum, tar_package_sha1sum, tar_package_sha256sum, zip_package_md5sum, zip_package_sha1sum, zip_package_sha256sum, release_notes_news_link, release_notes_news, release_notes_upgrading_instructions, release_notes_changes, release_notes_legacy_content FROM "release"');
+        $this->addSql('DROP TABLE "release"');
+        $this->addSql('CREATE TABLE "release" (version VARCHAR(255) NOT NULL, major_version DOUBLE PRECISION DEFAULT NULL, date DATETIME NOT NULL, type VARCHAR(255) NOT NULL, tar_package_md5sum VARCHAR(255) DEFAULT NULL, tar_package_sha1sum VARCHAR(255) DEFAULT NULL, tar_package_sha256sum VARCHAR(255) DEFAULT NULL, zip_package_md5sum VARCHAR(255) DEFAULT NULL, zip_package_sha1sum VARCHAR(255) DEFAULT NULL, zip_package_sha256sum VARCHAR(255) DEFAULT NULL, release_notes_news_link VARCHAR(255) DEFAULT NULL, release_notes_news CLOB DEFAULT NULL, release_notes_upgrading_instructions CLOB DEFAULT NULL, release_notes_changes CLOB DEFAULT NULL, release_notes_legacy_content CLOB DEFAULT NULL, PRIMARY KEY(version))');
+        $this->addSql('INSERT INTO "release" (version, major_version, date, type, tar_package_md5sum, tar_package_sha1sum, tar_package_sha256sum, zip_package_md5sum, zip_package_sha1sum, zip_package_sha256sum, release_notes_news_link, release_notes_news, release_notes_upgrading_instructions, release_notes_changes, release_notes_legacy_content) SELECT version, major_version, date, type, tar_package_md5sum, tar_package_sha1sum, tar_package_sha256sum, zip_package_md5sum, zip_package_sha1sum, zip_package_sha256sum, release_notes_news_link, release_notes_news, release_notes_upgrading_instructions, release_notes_changes, release_notes_legacy_content FROM __temp__release');
+        $this->addSql('DROP TABLE __temp__release');
+        $this->addSql('CREATE INDEX IDX_9E47031D17E84B00 ON "release" (major_version)');
+    }
+}

--- a/src/Repository/MajorVersionRepository.php
+++ b/src/Repository/MajorVersionRepository.php
@@ -120,7 +120,7 @@ class MajorVersionRepository extends EntityRepository
      */
     private function majorVersionDescending(MajorVersion $majorVersion): array
     {
-        $releases = $majorVersion->getReleases()->toArray();
+        $releases = $majorVersion->getReleasesWithoutElts()->toArray();
 
         usort(
             $releases,

--- a/src/Repository/MajorVersionRepository.php
+++ b/src/Repository/MajorVersionRepository.php
@@ -44,7 +44,7 @@ class MajorVersionRepository extends EntityRepository
         $data = [];
         foreach ($all as $version) {
             if ($excludeElts) {
-                $version->removeEltsReleases();
+                $version = $this->removeEltsReleases($version);
             }
             $data[$this->formatVersion($version->getVersion())] = $version;
         }
@@ -133,5 +133,18 @@ class MajorVersionRepository extends EntityRepository
         );
 
         return $releases;
+    }
+
+    /**
+     * @param MajorVersion $majorVersion
+     * @return MajorVersion
+     */
+    private function removeEltsReleases(MajorVersion $majorVersion): MajorVersion
+    {
+        $majorVersion->setReleases($majorVersion->getReleases()->filter(static function (Release $release) {
+            return !$release->isElts();
+        }));
+
+        return $majorVersion;
     }
 }

--- a/src/Repository/MajorVersionRepository.php
+++ b/src/Repository/MajorVersionRepository.php
@@ -32,20 +32,30 @@ class MajorVersionRepository extends EntityRepository
 
     public function findAllPreparedForJson()
     {
-        $data = $this->findAllGroupedByMajor(true);
+        $data = $this->findCommunityVersionsGroupedByMajor();
         $data = array_merge($data, $this->findStableReleases());
         $data = array_merge($data, $this->findLtsReleases());
         return $data;
     }
 
-    public function findAllGroupedByMajor(bool $excludeElts = false): array
+    public function findAllGroupedByMajor(): array
     {
         $all = $this->findAll();
         $data = [];
         foreach ($all as $version) {
-            if ($excludeElts) {
-                $version = $this->removeEltsReleases($version);
-            }
+            $data[$this->formatVersion($version->getVersion())] = $version;
+        }
+        uksort($data, 'version_compare');
+        $data = array_reverse($data);
+        return $data;
+    }
+
+    public function findCommunityVersionsGroupedByMajor(): array
+    {
+        $all = $this->findAll();
+        $data = [];
+        foreach ($all as $version) {
+            $version = $this->removeEltsReleases($version);
             $data[$this->formatVersion($version->getVersion())] = $version;
         }
         uksort($data, 'version_compare');

--- a/src/Repository/MajorVersionRepository.php
+++ b/src/Repository/MajorVersionRepository.php
@@ -32,17 +32,20 @@ class MajorVersionRepository extends EntityRepository
 
     public function findAllPreparedForJson()
     {
-        $data = $this->findAllGroupedByMajor();
+        $data = $this->findAllGroupedByMajor(true);
         $data = array_merge($data, $this->findStableReleases());
         $data = array_merge($data, $this->findLtsReleases());
         return $data;
     }
 
-    public function findAllGroupedByMajor(): array
+    public function findAllGroupedByMajor(bool $excludeElts = false): array
     {
         $all = $this->findAll();
         $data = [];
         foreach ($all as $version) {
+            if ($excludeElts) {
+                $version->removeEltsReleases();
+            }
             $data[$this->formatVersion($version->getVersion())] = $version;
         }
         uksort($data, 'version_compare');
@@ -120,7 +123,7 @@ class MajorVersionRepository extends EntityRepository
      */
     private function majorVersionDescending(MajorVersion $majorVersion): array
     {
-        $releases = $majorVersion->getReleasesWithoutElts()->toArray();
+        $releases = $majorVersion->getReleases()->toArray();
 
         usort(
             $releases,


### PR DESCRIPTION
This PR adds a boolean to releases to indicate if this release is ELTS or not. Default is false, both in the database as well as in the entity when it is instantiated. When creating a new release entity, ELTS must be explicitly set to true.