### PR TITLE
[TASK] Update latest TYPO3 v10 version to offer version 10.2

### DIFF
--- a/src/Service/ComposerPackagesService.php
+++ b/src/Service/ComposerPackagesService.php
@@ -458,8 +458,8 @@ class ComposerPackagesService
             'value' => '*'
         ],
         [
-            'name' => 'TYPO3 10.1',
-            'value' => '^10.1'
+            'name' => 'TYPO3 10.2',
+            'value' => '^10.2'
         ],
         [
             'name' => 'TYPO3 9.5 LTS',


### PR DESCRIPTION
When selecting composer packages in the **Composer Helper** section, users can also choose a specific TYPO3 version. This change updates the latest TYPO3 v10 version so that the dropdown box offers TYPO3 10.2.

Resolves #67