### PR TITLE
[TASK] Add link to packagist

### DIFF
--- a/templates/default/composer-repository.html.twig
+++ b/templates/default/composer-repository.html.twig
@@ -9,7 +9,7 @@
     {% frame with { color: 'light' } %}
         <h2>What Is It?</h2>
         <p>TYPO3 offers a <a href="https://getcomposer.org/" target="_blank" rel="noopener">Composer</a> repository, enabling you to install TYPO3 extensions from the <a href="https://extensions.typo3.org">TYPO3 Extension Repository</a> (TER) including their TER dependencies via Composer.</p>
-        <p class="deprecated">Please note, the usage of this composer repository is deprecated. Instead use the extensions published on Packagist, which is prefered. As fall back for not published extensions you can use this repository.</p>
+        <p class="deprecated">Please note, the usage of this composer repository is deprecated. Instead use the extensions published on <a href="{{ packagist.search }}" target="_blank" rel="noopener">Packagist</a>, which is prefered. As fall back for not published extensions you can use this repository.</p>
         <p>This repository includes only the following TYPO3 CMS extensions:</p>
         <ul>
             <li>All TYPO3 extensions that are uploaded to TER, including insecure versions.


### PR DESCRIPTION
Because of the removal of the top buttons packagist should get linked in the text. This link I removed before because of the red warning box which made the link unreadable.